### PR TITLE
Enable EventEmitter2s way of identifying event in callback.

### DIFF
--- a/src/flux-angular.js
+++ b/src/flux-angular.js
@@ -220,12 +220,17 @@ angular.module('flux', [])
         eventName = '*';
       }
 
-      callback = callback.bind(this);
+      var self = this;
+      var callbackWrapper = function() {
+        var args = [].slice.call(arguments);
+        self.dispatcherEvent = this.event;
+        callback.apply(self, args);
+      }
 
       var store = flux.getStore(storeExport);
       var addMethod = eventName === '*' ? 'onAny' : 'on';
       var removeMethod = eventName === '*' ? 'offAny' : 'off';
-      var args = eventName === '*' ? [callback] : [eventName, callback];
+      var args = eventName === '*' ? [callbackWrapper] : [eventName, callbackWrapper];
       store[addMethod].apply(store, args);
 
       // Remove any listeners to the store when scope is destroyed (GC)


### PR DESCRIPTION
Quick way of wrapping the original event property that is available in EventEmitter2 callbacks on the 
'this'. It's wrapped as a new property named 'dispatcherEvent".

```
$scope.$listenTo(MyStore, "comments.*", function() {
  console.log("Original event: " + this.dispatcherEvent);
}
```
