### PR TITLE
Added module.exports = 'flux'

### DIFF
--- a/src/flux-angular.js
+++ b/src/flux-angular.js
@@ -236,3 +236,5 @@ angular.module('flux', [])
     };
 
   }]);
+
+module.exports = 'flux';


### PR DESCRIPTION
https://github.com/christianalfoni/flux-angular/issues/52

This follows the typical CommonJS angular module pattern allowing it to be directly required into an angular module's dependency array.  Currently the module doesn't have any exports, so `require('flux-angular')` exports `Object {}`

Example:

```js
angular.module('myModule', [
  require('flux-angular') // exports "flux"
]);
```