### PR TITLE
[docs] Clarify behavior of flux.listenTo in relationship to the scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ object the callback is triggered and our scope properties can be synced with
 the store.
 
 When using `.$listenTo()`, the listener will be cleaned up when the scope of
-the controller is destroyed. If you'd prefer to manage clean up of the event
-listener, the `flux.listenTo()` method returns a callback that will unsubscribe
-from the event listener. Unlike `.$listenTo()`, `flux.listenTo()` will not call
-the callback as part of setting up the listener.
+the controller is destroyed. Alternatively, `flux.listenTo()` does not
+unsubscribe when a scope is destroyed, instead it returns a callback that will
+unsubscribe from the event listener. Unlike `.$listenTo()`, `flux.listenTo()`
+will not call the callback as part of setting up the listener.
 
 ### Dispatch actions
 


### PR DESCRIPTION
It wasn't clear that `flux.listenTo` isn't cleaned up when the scope is destroyed